### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-transformers==4.49.0
-vllm==0.8.3
+vllm<0.8.3
+transformers>=4.51.0
 qwen_agent
 qwen_vl_utils
 torch


### PR DESCRIPTION
Fixed package conflict : fix INFO: pip is looking at multiple versions of vllm to determine which version is compatible with other requirements. This could take a while. ERROR: Cannot install -r requirements.txt (line 2) and transformers==4.49.0 because these package versions have conflicting dependencies. The conflict is caused by: The user requested transformers==4.49.0 vllm 0.8.3 depends on transformers>=4.51.0 To fix this you could try to: 1. loosen the range of package versions you've specified 2. remove package versions to allow pip attempt to solve the dependency conflict ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts